### PR TITLE
Typo in TYPES.Item.criticalinjury

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -3,7 +3,7 @@
   "TYPES.Actor.npc": "NPC",
   "TYPES.Actor.vaesen": "Vaesen",
   "TYPES.Actor.headquarter": "Headquarter",
-  "TYPES.Item.criticalinjury": "Critical Injury",
+  "TYPES.Item.criticalInjury": "Critical Injury",
   "TYPES.Item.weapon": "Weapon",
   "TYPES.Item.armor": "Armor",
   "TYPES.Item.talent": "Talent",


### PR DESCRIPTION
There is an typo in the camelcase of this label