### PR TITLE
🐛 Allow NPCs to have some statuses

### DIFF
--- a/script/util/token.js
+++ b/script/util/token.js
@@ -9,11 +9,16 @@ export class VaesenTokenHUD extends TokenHUD {
     var actor = this.object.document.actor;
 
     if (actor.type === "player") {  
-      return super._getStatusEffectChoices();;
+      return super._getStatusEffectChoices();
     }
 
     if (actor.type === "npc") {
-      return [];
+      let statuses = super._getStatusEffectChoices();
+      for (const key of Object.keys(statuses)) {
+        if (key.startsWith("systems/vaesen/asset/status/"))
+          delete statuses[key];
+      }
+      return statuses;
     }
 
     if (actor.type === "vaesen") {


### PR DESCRIPTION
By the system, they will have only the slow and fast action. But if the GM uses some module that includes more statuses, that will be allowed too. Only the "player" Vaesen's statuses are being removed for NPCs now. fix #110